### PR TITLE
Crates updated their code breaking the theme.

### DIFF
--- a/css/crates.io.css
+++ b/css/crates.io.css
@@ -32,7 +32,7 @@ body {
     border-top: 11px solid #191f26;
 }
 
-#main {
+main[class^="_main_"] {
     background-color: transparent;
     border-radius: 0px;
     box-shadow: none;
@@ -163,7 +163,7 @@ div.exact-match h1 {
     box-shadow: 0px 6px 20px 0px black;
 }
 
-#crates-heading {
+.crates-heading {
     background-color: #141920;
 }
 


### PR DESCRIPTION
Note that there is some pseudo random looking class on `main`. I'm not sure
how permanent that selector is going to be, but just specifying main doesn't
override their css.