### PR TITLE
Fix crates.io footer colours

### DIFF
--- a/css/crates.io.css
+++ b/css/crates.io.css
@@ -439,3 +439,12 @@ img.download {
 [class^="_crate-downloads_"] [class^="_graph_"] text {
     fill: #c5c5c5;
 }
+
+/* footer */
+footer[class^="_footer_"] {
+    background: #0f1419;
+}
+
+footer[class^="_footer_"] [class^="_sep_"] {
+    color: #5c6773;
+}


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/4507647/101326421-57ee2300-38c1-11eb-8c50-627439400f56.png)
After:
![image](https://user-images.githubusercontent.com/4507647/101326445-61778b00-38c1-11eb-86df-b159def16fc3.png)
